### PR TITLE
library/dpkg_reconfigure: Add 'type' parameter to module interface (n…

### DIFF
--- a/library/dpkg_reconfigure
+++ b/library/dpkg_reconfigure
@@ -146,8 +146,8 @@ def main():
 
     module = AnsibleModule(
         argument_spec = dict(
-           pkg   = dict(required=True),
-           answers  = dict(required=True),
+           pkg   = dict(required=True, type='str'),
+           answers  = dict(required=True, type='dict'),
         )
     )
 


### PR DESCRIPTION
…eeded for Ansible 2)

Tested with Ansible 2.1.1.0

Without these type annotations, the module is unable to parse the answers parameter. Still works for Ansible 1.9.4
